### PR TITLE
Reinstate-workflows

### DIFF
--- a/.github/workflows/create-template-config.yml
+++ b/.github/workflows/create-template-config.yml
@@ -64,7 +64,7 @@ jobs:
         uses: docker://orrosenblatt/validate-json-action:latest
         env:
           INPUT_SCHEMA: 'data_curator_config/schemas/dca_template_config.schema.json'
-          INPUT_JSONS: ${{ inputs.file }}
+          INPUT_JSONS: $FILE
       
       - name: Open PR
         uses: peter-evans/create-pull-request@v5
@@ -74,4 +74,4 @@ jobs:
           delete-branch: true
           branch-suffix: timestamp
           add-paths: |
-            ${{ inputs.file }}
+            $FILE

--- a/.github/workflows/create-template-config.yml
+++ b/.github/workflows/create-template-config.yml
@@ -27,9 +27,15 @@ on:
       data_model:
         description: URL to a jsonld data model file
         required: true
-      # file:
-      #   description: File name path to save the template config
-      #   required: true
+        default: https://raw.githubusercontent.com/eliteportal/data-models/reinstate-workflows/EL.data.model.jsonld
+      file:
+        description: File name path to save the template config
+        required: true
+        default: dca-template-config.json
+      data_model_labels:
+        description: How schematic reads data model labels. Default 'class_label'. Can also be 'display_label'.
+        required: true
+        default: class_label
       include_schemas:
         description: Space-separated string of schemas to include in output. Must be empty if using exclude_schemas.
         required: false
@@ -59,12 +65,13 @@ jobs:
           file: $FILE
           include_schemas: ${{ inputs.include_schemas }}
           exclude_schemas: ${{ inputs.exclude_schemas }}
+          data_model_labels: $${{inputs.data_model_labels}}
         
       - name: Validate Config File
         uses: docker://orrosenblatt/validate-json-action:latest
         env:
           INPUT_SCHEMA: 'data_curator_config/schemas/dca_template_config.schema.json'
-          INPUT_JSONS: $FILE
+          INPUT_JSONS: ${{ inputs.file }}
       
       - name: Open PR
         uses: peter-evans/create-pull-request@v5
@@ -74,4 +81,4 @@ jobs:
           delete-branch: true
           branch-suffix: timestamp
           add-paths: |
-            $FILE
+            ${{ inputs.file }}

--- a/.github/workflows/create-template-config.yml
+++ b/.github/workflows/create-template-config.yml
@@ -27,15 +27,15 @@ on:
       data_model:
         description: URL to a jsonld data model file
         required: true
-        default: https://raw.githubusercontent.com/eliteportal/data-models/reinstate-workflows/EL.data.model.jsonld
+        default: 'https://raw.githubusercontent.com/eliteportal/data-models/reinstate-workflows/EL.data.model.jsonld'
       file:
         description: File name path to save the template config
         required: true
-        default: dca-template-config.json
+        default: 'dca-template-config.json'
       data_model_labels:
         description: How schematic reads data model labels. Default 'class_label'. Can also be 'display_label'.
         required: true
-        default: class_label
+        default: 'class_label'
       include_schemas:
         description: Space-separated string of schemas to include in output. Must be empty if using exclude_schemas.
         required: false

--- a/.github/workflows/create-template-config.yml
+++ b/.github/workflows/create-template-config.yml
@@ -1,5 +1,8 @@
-# --------------------------------------------------------------------------------------------------
 # GitHub Action to create a DCA template config json file for a data model
+
+# This action should be run manually after: adding, removing, or renaming any manifest templates in the json-ld data model, and successful completion of `update_data_model.yml`
+# This action should run before: using a new template in the Data Curator App
+# * this action must be triggered manually and the resulting PR must be reviewed and merged to complete the template config changes
 # 
 # This action creates a json file named with the `file` input argument using 
 # the data model supplied to the `data_model` argument. It will validate the 
@@ -14,9 +17,11 @@
 # to run on other triggers. Consult the github doc below for more information.
 # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
 #
-# The resulting file with contain one entry for each attribute in the data model that `dependsOn`
+# The resulting file will contain one entry for each attribute in the data model that `dependsOn`
 # "Component". To include a subset of these attributes, use either `include_schemas` or
-# `exclude_schemas` in the call to `datacurator::write_dca_template_config()`
+# `exclude_schemas` in the call to `datacurator::write_dca_template_config()`. The "type" parameter 
+# for each template will be `file` if the `DependsOn` column for that template includes the 
+# attribute "Filename"; if not the type will be `record`. 
 #
 # --------------------------------------------------------------------------------------------------
 
@@ -65,7 +70,7 @@ jobs:
           file: ${{ inputs.file }}
           include_schemas: ${{ inputs.include_schemas }}
           exclude_schemas: ${{ inputs.exclude_schemas }}
-          data_model_labels: ${{inputs.data_model_labels}}
+          data_model_labels: ${{ inputs.data_model_labels }}
         
       - name: Validate Config File
         uses: docker://orrosenblatt/validate-json-action:latest

--- a/.github/workflows/create-template-config.yml
+++ b/.github/workflows/create-template-config.yml
@@ -62,7 +62,7 @@ jobs:
         uses: sage-bionetworks/dca-template-config-action@main
         env:
           data_model: ${{ inputs.data_model }}
-          file: $FILE
+          file: ${{ inputs.file }}
           include_schemas: ${{ inputs.include_schemas }}
           exclude_schemas: ${{ inputs.exclude_schemas }}
           data_model_labels: ${{inputs.data_model_labels}}

--- a/.github/workflows/create-template-config.yml
+++ b/.github/workflows/create-template-config.yml
@@ -65,7 +65,7 @@ jobs:
           file: $FILE
           include_schemas: ${{ inputs.include_schemas }}
           exclude_schemas: ${{ inputs.exclude_schemas }}
-          data_model_labels: $${{inputs.data_model_labels}}
+          data_model_labels: ${{inputs.data_model_labels}}
         
       - name: Validate Config File
         uses: docker://orrosenblatt/validate-json-action:latest

--- a/.github/workflows/dcc_config_repo_dispatch.yml
+++ b/.github/workflows/dcc_config_repo_dispatch.yml
@@ -11,12 +11,12 @@ name: dcc_config_repo_dispatch
 # Can specify other branches or triggers for this workflow
 # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    types:
-      - closed # requires if_merged job below to run only during a merged PR
+  # push:
+  #   branches:
+  #     - main
+  # pull_request:
+  #   types:
+  #     - closed # requires if_merged job below to run only during a merged PR
   workflow_dispatch:
 
 # Edit these variables for your data model

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,9 +1,8 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
+# Builds and deploys the ELITE metadata dictionary as a Jekyll site to GitHub Pages
 
-# Sample workflow for building and deploying a Jekyll site to GitHub Pages
+# Preceding: dictionary docs and materials are updated by the update_metadata_dictionary.yml
+# Postceding: check the updated site at https://eliteportal.github.io/data-models/
+
 name: Deploy Jekyll site to Pages
 
 on:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,7 +1,7 @@
 # Builds and deploys the ELITE metadata dictionary as a Jekyll site to GitHub Pages
 
-# Preceding: dictionary docs and materials are updated by the update_metadata_dictionary.yml
-# Postceding: check the updated site at https://eliteportal.github.io/data-models/
+# This action should automatically run after: dictionary docs and materials are updated by update_metadata_dictionary.yml workflow
+# After this action completes: check the updated site at https://eliteportal.github.io/data-models/
 
 name: Deploy Jekyll site to Pages
 

--- a/.github/workflows/update_data_model.yml
+++ b/.github/workflows/update_data_model.yml
@@ -1,7 +1,9 @@
-# This workflow is used to convert changed EL.data.model.csv to EL.data.model.jsonld
-# It will run any time a PR is opened that includes changes to the 'modules/' directory
-# Before this: manually or programmatically editing the module csvs and opening a PR
-# After this: merging the PR to main will update the dictionary site files (update_metadata_dictionary.yml)
+# This workflow is used to combine all the data model attributes in the "modules" subdirectory into one csv,
+# and then convert the csv to the json-ld data model.
+
+# This action should automatically run after: manually or programmatically editing the module csvs and opening a PR
+# This action should run before: merging the PR to main and updating the dictionary site files (update_metadata_dictionary.yml),
+# or updating the dca-template-config file if template was added, removed, or renamed (create-template-config.yml)
 
 name: Update Data Model
 

--- a/.github/workflows/update_data_model.yml
+++ b/.github/workflows/update_data_model.yml
@@ -1,54 +1,48 @@
 # This workflow is used to convert changed EL.data.model.csv to EL.data.model.jsonld
-# and push the updated ELITE.data.model.jsonld to feature branch
-# intended to be used after updating the individual modules
-
-# July 2024: currently only runs on workflow dispatch (manual trigger); needs fixed
+# It will run any time a PR is opened that includes changes to the 'modules/' directory
+# Before this: manually or programmatically editing the module csvs and opening a PR
+# After this: merging the PR to main will update the dictionary site files (update_metadata_dictionary.yml)
 
 name: Update Data Model
 
 on:
-  #pull_request:
-  # branches: main
+  pull_request:
+   branches: main
     # runs on changes to module csvs
-  # paths: 'modules/**'
+   paths: 'modules/**'
+
   workflow_dispatch:
+
 jobs:
   CI:
-    name: schema-convert
+    name: update-data-model
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.9"
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  
 
-      - name: Install Schematic
-        shell: bash
-        run: |
-          pip3 install poetry
-          git clone --single-branch --branch main https://github.com/Sage-Bionetworks/schematic.git
-          cd schematic
-          poetry build
-          pip3 install dist/schematicpy-*-py3-none-any.whl
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+        cache: 'pip'
+  
+    - name: Install Poetry
+      uses: snok/install-poetry@v1
 
-      - name: Join data model
-        shell: bash
-        run: bash data_model_creation/update_data_model.sh
-        
-      - uses: r-lib/actions/pr-fetch@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Install dependencies
+      run: |
+        poetry install
 
-      - name: Commit the changes
-        run: |
-          git config --local user.name "$GITHUB_ACTOR"
-          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          git add EL.data.model.jsonld
-          git commit -m "GitHub Action: convert *.model.csv to *.model.jsonld" || echo "No changes to commit"
-
-      - uses: r-lib/actions/pr-push@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Join data model and convert to json-ld
+      run: |
+        poetry run python data_model_creation/join_data_model.py
+    
+    - name: Commit changes
+      uses: EndBug/add-and-commit@v9
+      with:
+        message: 'Github Action: Joined modules and converted to json-ld data model'

--- a/.github/workflows/update_data_model.yml
+++ b/.github/workflows/update_data_model.yml
@@ -45,4 +45,5 @@ jobs:
     - name: Commit changes
       uses: EndBug/add-and-commit@v9
       with:
+        default_author: github_actions
         message: 'Github Action: Joined modules and converted to json-ld data model'

--- a/.github/workflows/update_metadata_dictionary.yml
+++ b/.github/workflows/update_metadata_dictionary.yml
@@ -1,18 +1,18 @@
-# Updates the metadata dictionary that is @ https://eliteportal.github.io/data-dictionary/
-
-# July 2024: currently only runs on workflow dispatch (manual trigger); needs fixed
+# Workflow that updates the metadata dictionary materials in _site and _data after changes to the data model
+# Preceding: This should run after PR with changes to the data model is merged into main (update_data_model.yml)
+# Postceding: After this runs, the Github Pages deployment workflow should run (pages.yml)
 
 
 name: update_metadata_dictionary
 
 on:
-  #push:
-  # branches:
-  #    - main
+  push:
+   branches:
+      - main
   workflow_dispatch:
 
 jobs:
-  changed_files:
+  dictionary:
     runs-on: ubuntu-latest
     name: update term files and pages
     steps:
@@ -44,4 +44,5 @@ jobs:
       - name: Commit changes
         uses: EndBug/add-and-commit@v9
         with:
-          message: 'Updated dictionary term files and term pages'
+          message: 'Github Action: Updated dictionary term files and term pages'
+          default_author: github_actions

--- a/.github/workflows/update_metadata_dictionary.yml
+++ b/.github/workflows/update_metadata_dictionary.yml
@@ -1,6 +1,7 @@
-# Workflow that updates the metadata dictionary materials in _site and _data after changes to the data model
-# Preceding: This should run after PR with changes to the data model is merged into main (update_data_model.yml)
-# Postceding: After this runs, the Github Pages deployment workflow should run (pages.yml)
+# Workflow that updates the metadata dictionary materials in docs/ and _data/ after changes to the data model
+
+# This action should automatically run after: a PR with changes to the data model is merged into main (update_data_model.yml)
+# This action should run before: the Github Pages deployment workflow is run to publish changes to the dictionary site (pages.yml)
 
 
 name: Update Metadata Dictionary

--- a/.github/workflows/update_metadata_dictionary.yml
+++ b/.github/workflows/update_metadata_dictionary.yml
@@ -3,7 +3,7 @@
 # Postceding: After this runs, the Github Pages deployment workflow should run (pages.yml)
 
 
-name: update_metadata_dictionary
+name: Update Metadata Dictionary
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -6,22 +6,25 @@ There is a separate [data-dictionary](https://github.com/eliteportal/data-dictio
 
 <!-- toc -->
 
-- [EL Metadata Dictionary Site](#el-metadata-dictionary-site)
-  * [Updating Metadata Dictionary Site -- interim processes](#updating-metadata-dictionary-site----interim-processes)
-    + [Building and previewing the site locally](#building-and-previewing-the-site-locally)
 - [EL Data Model](#el-data-model)
-  * [Editing data models - interim process](#editing-data-models---interim-process)
+  * [Editing the data model](#editing-the-data-model)
     + [Editing attributes by module](#editing-attributes-by-module)
       - [Adding a new valid value to an existing manifest column](#adding-a-new-valid-value-to-an-existing-manifest-column)
       - [Adding a new column to a manifest template](#adding-a-new-column-to-a-manifest-template)
     + [Notes on collaboratively editing csvs](#notes-on-collaboratively-editing-csvs)
-    + [Scraping Valid Values from Ontology](#scraping-valid-values-from-ontology)
-  * [Automations](#automations)
-    + [Updates to data model](#updates-to-data-model)
-    + [Updating the data dictionary](#updating-the-data-dictionary)
     + [Adding a new template](#adding-a-new-template)
-  * [Developing in a codespace](#developing-in-a-codespace)
-    + [Create Data Model Visualization Tree](#create-data-model-visualization-tree)
+- [EL Metadata Dictionary Site](#el-metadata-dictionary-site)
+  * [Updating Metadata Dictionary Site via Github Action](#updating-metadata-dictionary-site-via-github-action)
+- [Other things you can do in this repository](#other-things-you-can-do-in-this-repository)
+  * [Making changes WITHOUT Github Actions (locally or in a codespace):](#making-changes-without-github-actions-locally-or-in-a-codespace)
+    + [editing data model in a github codespace](#editing-data-model-in-a-github-codespace)
+    + [editing data model locally](#editing-data-model-locally)
+    + [updating dictionary site in a github codespace](#updating-dictionary-site-in-a-github-codespace)
+    + [updating dictionary site locally](#updating-dictionary-site-locally)
+  * [Building and previewing the jekyll site locally](#building-and-previewing-the-jekyll-site-locally)
+  * [Scraping Valid Values from Ontology](#scraping-valid-values-from-ontology)
+  * [DCA config repo dispatch](#dca-config-repo-dispatch)
+  * [Create Data Model Visualization Tree](#create-data-model-visualization-tree)
   * [Developers](#developers)
     + [Files](#files)
     + [To setup environment](#to-setup-environment)
@@ -29,87 +32,13 @@ There is a separate [data-dictionary](https://github.com/eliteportal/data-dictio
 
 <!-- tocstop -->
 
-# EL Metadata Dictionary Site
-
-EL Metadata Dictionary is a [Jekyll](https://jekyllrb.com/) site utilizing [Just the Docs](https://just-the-docs.github.io/just-the-docs/) theme and is published on [GitHub Pages](https://pages.github.com/).
-
-- `index.md` is the home page
-- `_config.yml` can be used to tweak Jekyll settings, such as theme, title
-- `_layout/` contains html templates we use to generate the web pages for each data model term
-- `_data/` folder stores data for Jekyll to use when generating the site
-- files in `docs/` will be accessed by GitHub Actions workflow to build the site
-- two scripts in `processes/` can be run to generate updated files in `_data/` and `docs/` to publish changes in the data model to the dictionary site
-- `.env` contains the link to the data model that the dictionary site is based on
-- `Gemfile` is package dependencies for buildling the website
-- `pyproject.toml` and `poetry.lock` list the python and package dependencies for the scripts that update both the data model and the data dictionary site
-- You can add additional descriptions to home page or specific page by directly editing `index.md` or markdown files in `docs/`.
-
-## Updating Metadata Dictionary Site -- interim processes
-
-Interim process to update the metadata dictionary site after changes have been made to the data model:
-
-:note: Note: do this in a SEPARATE PR after changes to the data model are merged to main. The scripts to do this reference the data model at the url in `processess/.env`, which is the main branch of this repo. It's not the most elegant right now but keeping the data model updates and the dictionary site updates as separate steps will make rolling back errors easier while we shore up this process.
-
-### UPDATING DICTIONARY SITE IN A GITHUB CODESPACE:
-
-1. Start your codespace or build a new one. The codespace should build with a container image that includes the package manager `poetry`. You don't need to install poetry. It should also run the command `poetry install` after you launch it, which will tell poetry to install all the python libraries that are specified by this project (this will include schematic).
-
-2. Make a new branch. 
-
-3. From the top-level data-models directory, run `poetry run python processes/data_manager.py`. This should update some files within `_data/`
-
-4. Then run `poetry run python processes/page_manager.py`. This should update files within `docs/`. 
-
-5. Optional: you can run `poetry run python processes/create_network_graph.py` to create the schema visualization network graph. This is out of date and relatively unused, but it will be good to update and make more robust later.
-
-6. Commit changes to your branch and open a PR. After review is passed and the changes are merged to main, a Github action will run via the `pages.yml` workflow to build and deploy the site to https://eliteportal.github.io/data-models/
-
-### UPDATING DICTIONARY SITE LOCALLY: 
-
-1. Make sure you have the `poetry` dependency manager [installed](https://python-poetry.org/docs/#installing-with-the-official-installer) in your workspace. 
-
-Follow steps 2-5 from the section [above](#in-a-github-codespace)
-
-6. Optional: Preview the website locally by running `bundle exec jekyll serve`.
-
-7. Commit changes to your branch and open a PR. After review is passed and the changes are merged to main, a Github action will run via the `pages.yml` workflow to build and deploy the site to https://eliteportal.github.io/data-models/
-
-
-### Building and previewing the site locally
-
-1. Install Jekyll `gem install bundler jekyll`
-2. Install Bundler `bundle install`
-3. Run `bundle exec jekyll serve` to build your site and preview it at `http://localhost:4000`. The built site is stored in the directory `_site`.
-
-
 # EL Data Model
 
 **EL.data.model.\* ([csv](https://raw.githubusercontent.com/eliteportal/data-models/main/EL.data.model.csv) | [jsonld](https://raw.githubusercontent.com/eliteportal/data-models/main/EL.data.model.jsonld))**: this is the current, "live" version of the EL Portal data model. It is being used by both the staging and production versions of the multitenant Data Curator App.
 
-## Editing data models - interim process
+## Editing the data model
 
-🚧 The Github action that automatically compiles the module csvs and converts to a json-ld is not working as expected as of June 2024. For now, please use the following procedure to manually compile attribute modules and convert the updated data model to a json-ld:
-
-The main branch of this repo is protected, so you cannot push changes to main. To make changes to the data model:
-
-### EDITING DATA MODEL IN A GITHUB CODESPACE:
-
-1. Start your codespace or build a new one. The codespace should build with a container image that includes the package manager `poetry`. You don't need to install poetry. It should also run the command `poetry install` after you launch it, which will tell poetry to install all the python libraries that are specified by this project (this will include schematic).
-2. Make a new branch. On that branch, make and commit any changes. Please write informative commit messages in case we need to track down data model inconsistencies or introduced bugs.
-3. Still in the top-level directory, run `poetry run python data_model_creation/join_data_model.py` from the terminal. This will run a python script that joins all the module csvs, does a few data frame quality checks, and uses `schematic schema convert` to create the updated json-ld data model.
-4. If the script succeeds, double check the version control history of your json-ld data model and make sure the changes you expected have been made! Save and commit all changes, then push your local branch to the remote.
-5. Open a pull request and request review from someone else on the EL DCC team. The Github Action that runs when you open a PR will currently fail -- you can ignore this. EL DCC team will perform manual checks before merging changes.
-6. After the PR is merged, delete your branch.
-
-### EDITING DATA MODEL LOCALLY:
-
-1. Start your codespace or build a new one. The codespace should build with a container image that includes the package manager `poetry`. You don't need to install poetry. It should also run the command `poetry install` after you launch it, which will tell poetry to install all the python libraries that are specified by this project (this will include schematic).
-
-Follow steps 2-4 [above](#editing-data-model-in-a-github-codespace)
-
-5. [Optional]: to generate a test manifest, run `poetry run schematic manifest -c path/to/config.yml get -dt RelevantDataType -s` from the terminal. This will generate a json schema, a manifest csv, and a link to a google sheet version of the manifest. DO NOT put any real data in the google sheet manifest! This is just an integration test to see if the manifest columns and drop downs look as expected. Don't commit the json schema and the manifest csv generated during this step to your branch -- these are ephemeral and should be deleted. 
-6. Open a pull request and request review from someone else on the EL DCC team. The Github Action that runs when you open a PR will currently fail -- you can ignore this. EL DCC team will perform manual checks before merging changes.
-7. After the PR is merged, delete your branch.
+The main branch of this repo is protected, so you cannot push changes to main. To edit the data model, create a new branch of this repository and make changes to the attribute csv files in the `modules/` subdirectory. Once you have made your changes, open a pull request. This will trigger a Github Action that automatically joins the attributes from the module csv, converts the csv data model to the json-ld format, and commits the changes to your PR. Please **do not** make changes to `EL.data.model.csv` or `EL.data.model.jsonld` by hand! 
 
 ### Editing attributes by module
 
@@ -156,57 +85,99 @@ A persistent issue is that manually editing csvs is challening. Some columns in 
 - Cloning the repo, making a branch, and opening csvs locally in Excel or another spreadsheet program 🖥️ : probably the best UI experience, but involves a few extra steps with git.
 - Using a [Github codespace](#developing-in-a-codespace) to launch VSCode in the browser, and editing with the pre-installed RainbowCSV extension 🌈 : Still difficult to edit csvs as plain text, but the color formatting and ability to use a soft word wrap makes it much easier to distinguish columns. [RainbowCSV](https://marketplace.visualstudio.com/items?itemName=mechatroner.rainbow-csv) lets you designate "sticky" rows and columns for easier scrolling, and also has a nice "CSVLint" function that will check for formatting errors after you make changes.
 
-We are exploring better solutions to this problem -- if you have ideas, tell us!
+### Adding a new template
 
-### Scraping Valid Values from Ontology
+If you add a new template manifest (e.g. for a new assay type), remove an existing manifest, or rename a manifest, you need to update the `dca-template-config.yml` file that DCA uses to populate the menu contributors will use to select their template. To do this, you must **manually trigger** the Github Action `create-template-config.yml`. This will re-create the DCA template config file and open a new PR with the changes. Review and merge the PR to complete the template config update. You can use the default input values provided when you manually trigger this workflow.
+
+# EL Metadata Dictionary Site
+
+The Metadata Dictionary site is at: https://eliteportal.github.io/data-models/. 
+
+EL Metadata Dictionary is a [Jekyll](https://jekyllrb.com/) site utilizing [Just the Docs](https://just-the-docs.github.io/just-the-docs/) theme and is published on [GitHub Pages](https://pages.github.com/).
+
+- `index.md` is the home page
+- `_config.yml` can be used to tweak Jekyll settings, such as theme, title
+- `_layout/` contains html templates we use to generate the web pages for each data model term
+- `_data/` folder stores data for Jekyll to use when generating the site
+- files in `docs/` will be accessed by GitHub Actions workflow to build the site
+- two scripts in `processes/` can be run to generate updated files in `_data/` and `docs/` to publish changes in the data model to the dictionary site
+- `.env` contains the link to the data model that the dictionary site is based on
+- `Gemfile` is package dependencies for buildling the website
+- `pyproject.toml` and `poetry.lock` list the python and package dependencies for the scripts that update both the data model and the data dictionary site
+- You can add additional descriptions to home page or specific page by directly editing `index.md` or markdown files in `docs/`.
+
+## Updating Metadata Dictionary Site via Github Action
+
+1. The dictionary site materials should be updated after you make changes to the data model ([see](#editing-the-data-model)). Once a PR with changes is reviewed and merged into main, the Github Action in `update_metadata_dictionary.yml` should automatically start. This action will update the files in `_data/` and `docs/` that are used to populate the dictionary website. 
+
+2. Once any changes are detected in the `_data/` or `docs/` folders on the main branch, another Github action called `pages.yml` will run to update the deployment to the Github pages website. Verify that the dictionary site looks as expected at https://eliteportal.github.io/data-models/. 
+
+# Other things you can do in this repository
+
+## Making changes WITHOUT Github Actions (locally or in a codespace):
+
+### editing data model in a github codespace
+
+1. Start your codespace or build a new one. The codespace should build with a container image that includes the package manager `poetry`. You don't need to install poetry. It should also run the command `poetry install` after you launch it, which will tell poetry to install all the python libraries that are specified by this project (this will include schematic).
+2. Make a new branch. On that branch, make and commit any changes. Please write informative commit messages in case we need to track down data model inconsistencies or introduced bugs.
+3. Still in the top-level directory, run `poetry run python data_model_creation/join_data_model.py` from the terminal. This will run a python script that joins all the module csvs, does a few data frame quality checks, and uses `schematic schema convert` to create the updated json-ld data model.
+4. If the script succeeds, double check the version control history of your json-ld data model and make sure the changes you expected have been made! Save and commit all changes, then push your local branch to the remote.
+5. Open a pull request and request review from someone else on the EL DCC team. The Github Action that runs when you open a PR will currently fail -- you can ignore this. EL DCC team will perform manual checks before merging changes.
+6. After the PR is merged, delete your branch.
+
+### editing data model locally
+
+1. Start your codespace or build a new one. The codespace should build with a container image that includes the package manager `poetry`. You don't need to install poetry. It should also run the command `poetry install` after you launch it, which will tell poetry to install all the python libraries that are specified by this project (this will include schematic).
+
+Follow steps 2-4 [above](#editing-data-model-in-a-github-codespace)
+
+5. [Optional]: to generate a test manifest, run `poetry run schematic manifest -c path/to/config.yml get -dt RelevantDataType -s` from the terminal. This will generate a json schema, a manifest csv, and a link to a google sheet version of the manifest. DO NOT put any real data in the google sheet manifest! This is just an integration test to see if the manifest columns and drop downs look as expected. Don't commit the json schema and the manifest csv generated during this step to your branch -- these are ephemeral and should be deleted. 
+6. Open a pull request and request review from someone else on the EL DCC team. The Github Action that runs when you open a PR will currently fail -- you can ignore this. EL DCC team will perform manual checks before merging changes.
+7. After the PR is merged, delete your branch.
+
+### updating dictionary site in a github codespace
+
+1. Start your codespace or build a new one. The codespace should build with a container image that includes the package manager `poetry`. You don't need to install poetry. It should also run the command `poetry install` after you launch it, which will tell poetry to install all the python libraries that are specified by this project (this will include schematic).
+
+2. Make a new branch. 
+
+3. From the top-level data-models directory, run `poetry run python processes/data_manager.py`. This should update some files within `_data/`
+
+4. Then run `poetry run python processes/page_manager.py`. This should update files within `docs/`. 
+
+5. Optional: you can run `poetry run python processes/create_network_graph.py` to create the schema visualization network graph. This is out of date and relatively unused, but it will be good to update and make more robust later.
+
+6. Commit changes to your branch and open a PR. After review is passed and the changes are merged to main, a Github action will run via the `pages.yml` workflow to build and deploy the site to https://eliteportal.github.io/data-models/
+
+### updating dictionary site locally
+
+1. Make sure you have the `poetry` dependency manager [installed](https://python-poetry.org/docs/#installing-with-the-official-installer) in your workspace. 
+
+Follow steps 2-5 from the section [above](#in-a-github-codespace)
+
+6. Optional: Preview the website locally by running `bundle exec jekyll serve`.
+
+7. Commit changes to your branch and open a PR. After review is passed and the changes are merged to main, a Github action will run via the `pages.yml` workflow to build and deploy the site to https://eliteportal.github.io/data-models/
+
+## Building and previewing the jekyll site locally
+
+1. Install Jekyll `gem install bundler jekyll`
+2. Install Bundler `bundle install`
+3. Run `bundle exec jekyll serve` to build your site and preview it at `http://localhost:4000`. The built site is stored in the directory `_site`.
+
+## Scraping Valid Values from Ontology
 
 ❓status unknown
 
 Use `scraping_valid_values.py` to pull in values from EBI OLS sources. 
 
-## Automations 
+## DCA config repo dispatch
 
-🚧 currently broken! Also the documentation here is from the AD data model, I don't think it's accurate for the EL repo.
- 
-When you open a PR that includes any changes to files in the `modules/` directory, a Github Action will automatically run before merging is allowed. This action:
+❓status unknown
 
-### Updates to data model
+`dcc_config_repo_dispatch.yml` -- Not sure what this is for, still investigating its use. Authorization is failing.
 
-1. Runs the `assemble_csv_data_model.py` script to concatenate the modular attribute csvs into one data frame, sort alphabetically by `Parent` and then `Attribute`, and write the combined dataframe to `EL.data.model.csv`. The action then commits the changes to the master data model csv.
-2. Installs `schematic` from the develop branch and runs `schema convert` on the newly-concatenated data model csv to generate a new version of the jsonld file `EL.data.model.jsonld`. The action also commits the changes to the jsonld.
-
-If this automated workflow fails, then the data model may be invalid and further investigation is needed.
-
-### Updating the data dictionary
-
-🚧 currently broken!
-
-1. Runs `update-data-dictionary.yaml` in order to reflect information found in the dictionary for contributors
-
-
-### Adding a new template
-
-❓ status unknown
-
-Recreates DCA template config
-
-❓ status unkown
-
-- Run the github action `create-template-config.yml` when adding new templates
-
-## Developing in a codespace
-
-:warning: If you are working in a Github Codespace, do NOT commit any Synapse credentials to the repository and do NOT use any real human data when testing data model function. This is not a secure environment!
-
-If you want to make changes to the data model and test them out by generating manifests with `schematic`, you can use the devcontainer in this repo with a Github Codespace. This will open a container in a remote instance of VSCode and install the latest version of schematic.
-
-Codespace secrets:
-
-- SYNAPSE_PAT: scoped to view and download permissions on the sysbio-dcc-tasks-01 Synapse service account
-- SERVICE_ACCOUNT_CREDS: these are creds for using the Google sheets api with schematic
-
-
-### Create Data Model Visualization Tree
+## Create Data Model Visualization Tree
 
 [Schematic API](https://schematic.api.sagebionetworks.org/v1/ui/)
 [Visualization Repository](https://github.com/Sage-Bionetworks/schema_visualization)


### PR DESCRIPTION
Update the CI/CD workflows for data model changes and metadata dictionary.

## Updating the data model with .github/workflows/update_data_model.yml
- uses the version of schematic in the pyproject.toml file instead of schematic develop
- uses a marketplace action to properly install poetry and setup dependencies from poetry lockfile
- runs on any PR that includes changes to the modules/ subdirectory
- commits are made by "github_actions" instead of individual account

## Updating the data dictionary site materials with .github/workflows/update_metadata_dictionary.yml
- uses the version of schematic in the pyproject.toml file instead of schematic develop
- uses a marketplace action to properly install poetry and setup dependencies from poetry lockfile
- runs on any changes merged or pushed to main (will catch changes to data model or any other configuration changes in the repo). This might be a little bit of a broad trigger, but the pages deployment job won't run unless there are actually changes made to the docs or _data folders
- commits made by "github_actions"

## deploying the GH pages site with .github/workflows/pages.yml
- added some comments but no other changes; this one works fine

## updating the dca-template-config.json
- added the data_model_labels input which is now used by DCA
- removed the env variable for $FILE and went back to using the 'file' input, which had been commented out
- added default values for the required inputs -- these should be what we use in 99.9% of cases

## Updated README
- this is starting to read like soup to me, so it may need changes. Probably also needs a flow chart. I don't know, there's so much in this repo that I do not understand the use of. 
