### PR TITLE
Add download link for metadata template

### DIFF
--- a/docs/template/assay_bsSeq_template.md
+++ b/docs/template/assay_bsSeq_template.md
@@ -9,7 +9,7 @@ title: assay bsSeq template
 {: .note-title } 
 >assay bsSeq template
 >
->Template for bsSeq [[Source]](Sage Bionetworks)
+>Template for bsSeq [[Download]](https://github.com/eliteportal/data-models/raw/refs/heads/main/elite-data/manifest-templates/EL_template_AssayBsSeqTemplate.xlsx)
 <table id="myTable" class="display" style="width:100%">
     <thead>
     {% for column in mydata[0] %}


### PR DESCRIPTION
Example for how to add download link to metadata template to the Data Dictionary

## Changes

`Source` has been changed to `Download` for ease of use by new users.
The download link should be taken from the `view raw` button when you view the template file on github
![image](https://github.com/user-attachments/assets/f17e5845-970e-46e7-a0bb-dc170415117b)

## Results
![image](https://github.com/user-attachments/assets/0bc09a55-5909-4a45-b021-dcec4dfa9198)


## To Test
When jekyll is installed locally the site can be tested by running
`bundle exec jekyll serve` and navigating to http://localhost:4000
