### PR TITLE
Adding download links to metadata dictionary site templates

### DIFF
--- a/docs/template/assay_RNAseq_template.md
+++ b/docs/template/assay_RNAseq_template.md
@@ -9,7 +9,7 @@ title: assay RNAseq template
 {: .note-title } 
 >assay RNAseq template
 >
->Template for RNAseq [[Source]](Sage Bionetworks)
+>Template for RNAseq [[Download]](https://github.com/eliteportal/data-models/raw/refs/heads/main/elite-data/manifest-templates/EL_template_AssayRNAseqTemplate.xlsx)
 <table id="myTable" class="display" style="width:100%">
     <thead>
     {% for column in mydata[0] %}

--- a/docs/template/assay_metabolomics_template.md
+++ b/docs/template/assay_metabolomics_template.md
@@ -9,7 +9,7 @@ title: assay metabolomics template
 {: .note-title } 
 >assay metabolomics template
 >
->Template for Metabolomics [[Source]](Sage Bionetworks)
+>Template for Metabolomics [[Download]](htps://github.com/eliteportal/data-models/raw/refs/heads/main/elite-data/manifest-templates/EL_template_AssayMetabolomicsTemplate.xlsx)
 <table id="myTable" class="display" style="width:100%">
     <thead>
     {% for column in mydata[0] %}

--- a/docs/template/assay_metagenomics_template.md
+++ b/docs/template/assay_metagenomics_template.md
@@ -9,7 +9,7 @@ title: assay metagenomics template
 {: .note-title } 
 >assay metagenomics template
 >
->Template for Metagenomics [[Source]](Sage Bionetworks)
+>Template for Metagenomics [[Download]](https://github.com/eliteportal/data-models/raw/refs/heads/main/elite-data/manifest-templates/EL_template_AssayMetagenomicsTemplate.xlsx)
 <table id="myTable" class="display" style="width:100%">
     <thead>
     {% for column in mydata[0] %}

--- a/docs/template/assay_microbiome_template.md
+++ b/docs/template/assay_microbiome_template.md
@@ -9,7 +9,7 @@ title: assay microbiome template
 {: .note-title } 
 >assay microbiome template
 >
->Template for Microbiome [[Source]](Sage Bionetworks)
+>Template for Microbiome [[Download]](https://github.com/eliteportal/data-models/raw/refs/heads/main/elite-data/manifest-templates/EL_template_AssayMicrobiomeTemplate.xlsx)
 <table id="myTable" class="display" style="width:100%">
     <thead>
     {% for column in mydata[0] %}

--- a/docs/template/assay_phenotype_human_template.md
+++ b/docs/template/assay_phenotype_human_template.md
@@ -9,7 +9,7 @@ title: assay phenotype human template
 {: .note-title } 
 >assay phenotype human template
 >
->Template for Phenotype_human [[Source]](Sage Bionetworks)
+>Template for Phenotype_human [[Download]](https://github.com/eliteportal/data-models/raw/refs/heads/main/elite-data/manifest-templates/EL_template_AssayPhenotypeHumanTemplate.xlsx)
 <table id="myTable" class="display" style="width:100%">
     <thead>
     {% for column in mydata[0] %}

--- a/docs/template/assay_proteomics_template.md
+++ b/docs/template/assay_proteomics_template.md
@@ -9,7 +9,7 @@ title: assay proteomics template
 {: .note-title } 
 >assay proteomics template
 >
->Template for Proteomics [[Source]](Sage Bionetworks)
+>Template for Proteomics [[Download]](https://github.com/eliteportal/data-models/raw/refs/heads/main/elite-data/manifest-templates/EL_template_AssayProteomicsTemplate.xlsx)
 <table id="myTable" class="display" style="width:100%">
     <thead>
     {% for column in mydata[0] %}

--- a/docs/template/assay_scRNAseq_template.md
+++ b/docs/template/assay_scRNAseq_template.md
@@ -9,7 +9,7 @@ title: assay scRNAseq template
 {: .note-title } 
 >assay scRNAseq template
 >
->Template for scRNAseq [[Source]](Sage Bionetworks)
+>Template for scRNAseq [[Download]](https://github.com/eliteportal/data-models/raw/refs/heads/main/elite-data/manifest-templates/EL_template_AssayScRNAseqTemplate.xlsx)
 <table id="myTable" class="display" style="width:100%">
     <thead>
     {% for column in mydata[0] %}

--- a/docs/template/assay_whole_genome_sequencing_template.md
+++ b/docs/template/assay_whole_genome_sequencing_template.md
@@ -9,7 +9,7 @@ title: assay whole genome sequencing template
 {: .note-title } 
 >assay whole genome sequencing template
 >
->Template for Whole_Genome_Sequencing [[Source]](Sage Bionetworks)
+>Template for Whole_Genome_Sequencing [[Download]](https://github.com/eliteportal/data-models/raw/refs/heads/main/elite-data/manifest-templates/EL_template_AssayWholeGenomeSequencingTemplate.xlsx)
 <table id="myTable" class="display" style="width:100%">
     <thead>
     {% for column in mydata[0] %}

--- a/docs/template/biospecimen_human_template.md
+++ b/docs/template/biospecimen_human_template.md
@@ -9,7 +9,7 @@ title: biospecimen human template
 {: .note-title } 
 >biospecimen human template
 >
->Template for Biospecimen_human [[Source]](Sage Bionetworks)
+>Template for Biospecimen_human [[Download]](https://github.com/eliteportal/data-models/raw/refs/heads/main/elite-data/manifest-templates/EL_template_BiospecimenHumanTemplate.xlsx)
 <table id="myTable" class="display" style="width:100%">
     <thead>
     {% for column in mydata[0] %}

--- a/docs/template/biospecimen_non_human_template.md
+++ b/docs/template/biospecimen_non_human_template.md
@@ -9,7 +9,7 @@ title: biospecimen non human template
 {: .note-title } 
 >biospecimen non human template
 >
->Template for Biospecimen_non_Human [[Source]](Sage Bionetworks)
+>Template for Biospecimen_non_Human [[Download]](https://github.com/eliteportal/data-models/raw/refs/heads/main/elite-data/manifest-templates/EL_template_BiospecimenNonHumanTemplate.xlsx)
 <table id="myTable" class="display" style="width:100%">
     <thead>
     {% for column in mydata[0] %}

--- a/docs/template/file_annotation_template.md
+++ b/docs/template/file_annotation_template.md
@@ -9,7 +9,7 @@ title: file annotation template
 {: .note-title } 
 >file annotation template
 >
->Base annotations for files in synapse [[Source]](Sage Bionetworks)
+>Base annotations for files in synapse [[Download]](https://github.com/eliteportal/data-models/raw/refs/heads/main/elite-data/manifest-templates/EL_template_FileAnnotationTemplate.xlsx)
 <table id="myTable" class="display" style="width:100%">
     <thead>
     {% for column in mydata[0] %}

--- a/docs/template/genotyping_human_template.md
+++ b/docs/template/genotyping_human_template.md
@@ -9,7 +9,7 @@ title: genotyping human template
 {: .note-title } 
 >genotyping human template
 >
->Template for Genotyping_Human [[Source]](Sage Bionetworks)
+>Template for Genotyping_Human [[Download]](https://github.com/eliteportal/data-models/raw/refs/heads/main/elite-data/manifest-templates/EL_template_GenotypingHumanTemplate.xlsx)
 <table id="myTable" class="display" style="width:100%">
     <thead>
     {% for column in mydata[0] %}

--- a/docs/template/individual_human_template.md
+++ b/docs/template/individual_human_template.md
@@ -9,7 +9,7 @@ title: individual human template
 {: .note-title } 
 >individual human template
 >
->Template for Individual_Human [[Source]](Sage Bionetworks)
+>Template for Individual_Human [[Download]](https://github.com/eliteportal/data-models/raw/refs/heads/main/elite-data/manifest-templates/EL_template_IndividualHumanTemplate.xlsx)
 <table id="myTable" class="display" style="width:100%">
     <thead>
     {% for column in mydata[0] %}

--- a/docs/template/individual_non_human_template.md
+++ b/docs/template/individual_non_human_template.md
@@ -9,7 +9,7 @@ title: individual non human template
 {: .note-title } 
 >individual non human template
 >
->Template for Individual_non_Human [[Source]](Sage Bionetworks)
+>Template for Individual_non_Human [[Download]](https://github.com/eliteportal/data-models/raw/refs/heads/main/elite-data/manifest-templates/EL_template_IndividualNonHumanTemplate.xlsx)
 <table id="myTable" class="display" style="width:100%">
     <thead>
     {% for column in mydata[0] %}

--- a/docs/template/study_folder_template.md
+++ b/docs/template/study_folder_template.md
@@ -9,7 +9,7 @@ title: study folder template
 {: .note-title } 
 >study folder template
 >
->Annotations for study folders [[Source]](Sage Bionetworks)
+>Annotations for study folders [[Download]](https://github.com/eliteportal/data-models/raw/refs/heads/main/elite-data/manifest-templates/EL_template_StudyFolderTemplate.xlsx)
 <table id="myTable" class="display" style="width:100%">
     <thead>
     {% for column in mydata[0] %}


### PR DESCRIPTION
Based on Gianna's PR example I changed the remainder of the links for the templates on the metadata dictionary site to be downloadable