### PR TITLE
Add App to Metadata Dictionary Workflow

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,14 @@
+# GitHub App Usage in Workflows
+
+## Commit to Main Bot
+These workflows use the `Commit to Main Bot` app to commit changes directly to the `main` branch of the repository. The app has been given an exception to bypass the branch protections present on that branch.
+
+### Permissions
+This app has been granted `read and write` access to the contents of the repository and `read-only` access to the metadata of the repository (which is the default for GitHub apps and mandatory). All other Organization, Account, and Optional features have not been granted or left as default. Copilot integration has not been enabled.
+
+### Authentication
+The private key for this app that is used in this repository was generated on 02/19/2025 and can be accessed in workflows through the `COMMIT_BOT_KEY` repository secret. The app ID is also stored as a Reopository variable under `COMMIT_BOT_ID`.
+
+### Used In
+
+- update_metadata_dictionary.yml

--- a/.github/workflows/update_metadata_dictionary.yml
+++ b/.github/workflows/update_metadata_dictionary.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/update_metadata_dictionary.yml
+++ b/.github/workflows/update_metadata_dictionary.yml
@@ -17,6 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     name: update term files and pages
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.COMMIT_BOT_ID }}
+          private-key: ${{ secrets.COMMIT_BOT_KEY }}
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  


### PR DESCRIPTION
This PR makes changes to remove the manual intervention required during the deployment of the pages site by updating the `Update Metadata Dictionary` workflow.

Resolves [DPE-1229](https://sagebionetworks.jira.com/browse/DPE-1229)

To facilitate these changes, modification were also made to the `eliteportal` github organization and the `data-models` repository.

## Changelog

### `eliteportal` organization
A new github app was created, the `Commit to main bot`, that belongs to this organization. This can technically be used in any other repository belonging to this organization but was created specifically to resolve the issues described in the linked ticket. Other members of the repository that have been added as app managers can modify this app if necessary.

### `data-models` repository
The app has been installed in this repository so that it can be used. The ID of the app and the private key of the app have been added as environment variables and secrets of the repository respectively. 
`main` is a protected branch that does not allow commits to be made directly to it. The app has been given permission to bypass these restrictions so that the workflow can commit changes directly to main without necessitating opening a PR and having a human review and merge it as in other workflows.

### Workflow file
This app is now used in the workflow file. A step has been added to get a token for the app and that token is used to checkout the branch and later to commit changes to `main`