### PR TITLE
[DPE-1247] Update template generation script to include download link

### DIFF
--- a/processes/page_manager.py
+++ b/processes/page_manager.py
@@ -78,7 +78,7 @@ def get_info(data_model: pd.DataFrame, term: str, column: str = "Attribute") -> 
     return results[0]
 
 
-def create_template_page(term: str, term_dict: dict) -> frontmatter.Post:
+def create_template_page(term: str, term_dict: dict, schema_names_frame: pd.DataFrame) -> frontmatter.Post:
     """
     Creates a new markdown page for a specific template within the website's documentation.
 
@@ -109,7 +109,7 @@ def create_template_page(term: str, term_dict: dict) -> frontmatter.Post:
     post.metadata["title"] = re.sub("_", r" ", term).strip()
     post.metadata["parent"] = term_dict["module"]
 
-    template_url = get_template_download_link(term)
+    template_url = get_template_download_link(term=term, schema_names_frame=schema_names_frame)
 
     # Inject term information into template content
     content_prefix = (
@@ -130,18 +130,39 @@ def create_template_page(term: str, term_dict: dict) -> frontmatter.Post:
 
     # return post
 
-def get_template_download_link(term: str) -> str:
+def get_manifest_schemas_name_frame(template_config_path: str = "dca-template-config.json") -> pd.DataFrame:
+    """
+    Loads the manifest schemas from a JSON configuration file into a pandas DataFrame.
+
+    Args:
+        template_config_path: The path to the JSON configuration file (str).
+
+    Returns:
+        A pandas DataFrame containing the manifest schemas.
+    """
+
+    with open(template_config_path, "r") as f:
+        json_template_configdata = json.load(f)
+
+    return pd.DataFrame.from_dict(json_template_configdata["manifest_schemas"])
+
+def get_template_download_link(term: str, schema_names_frame: pd.DataFrame) -> str:
+    """
+    Constructs the download URL for a specific template based on its schema name.
+    Args:
+        term: The name of the template (str).
+        schema_names_frame: A pandas DataFrame containing the schema names and display names.
+    Returns:
+        The download URL for the template (str).
+    """
     base_url = "https://github.com/eliteportal/data-models/raw/refs/heads/"
     templates_path = "main/elite-data/manifest-templates/"
     template_prefix = "EL_template_"
 
-    with open("dca-template-config.json", "r") as f:
-        json_template_configdata = json.load(f)
+    # Get the schema name corresponding to the term display name
+    schema_name = schema_names_frame.loc[schema_names_frame["display_name"]==term, "schema_name"].values[0]
 
-    manifest_schemas = pd.DataFrame.from_dict(json_template_configdata["manifest_schemas"])
-
-    schema_name = manifest_schemas.loc[manifest_schemas["display_name"]==term, "schema_name"].values[0]
-
+    # Build the url to directly trigger a download of the template
     download_url = base_url + templates_path + template_prefix + schema_name + ".xlsx"
 
     return download_url
@@ -337,6 +358,8 @@ if __name__ == "__main__":
     for module in modules:
         create_module_page(module)
 
+    schema_names_frame = get_manifest_schemas_name_frame()
+
     # Creating template pages
     print('---- Creating Template pages ----')
     templates = list(
@@ -345,7 +368,7 @@ if __name__ == "__main__":
     for template in templates:
         # term_attr = re.sub("_", " ", template)
         term_info = get_info(data_model, template, column="Attribute")
-        create_template_page(template, term_dict=term_info)
+        create_template_page(template, term_dict=term_info,schema_names_frame=schema_names_frame)
 
     # create attribute pages
     print("---- Creating attribute pages ----")

--- a/processes/page_manager.py
+++ b/processes/page_manager.py
@@ -29,6 +29,7 @@ from mdutils import fileutils
 from dotenv import dotenv_values
 from glob import glob
 import json
+from typing import Optional
 
 from toolbox import utils
 
@@ -131,7 +132,7 @@ def create_template_page(term: str, term_dict: dict, schema_names_dict: dict[str
 
     # return post
 
-def get_manifest_schemas_name_dict(template_config_path: str = "dca-template-config.json") -> dict[str, list[str]]:
+def get_manifest_schemas_name_dict(template_config_path: Optional[str] = "dca-template-config.json") -> dict[str, list[str]]:
     """
     Loads the manifest schemas from a JSON configuration file into a pandas DataFrame.
 
@@ -152,7 +153,7 @@ def get_manifest_schemas_name_dict(template_config_path: str = "dca-template-con
     schema_names_frame.drop('type',axis=1,inplace=True)
     schema_names_frame = schema_names_frame.set_index('display_name').T
 
-    
+
     return schema_names_frame.to_dict(orient='list')
 
 def get_template_download_link(term: str, schema_names_dict: dict[str, list[str]]) -> str:

--- a/processes/page_manager.py
+++ b/processes/page_manager.py
@@ -159,9 +159,11 @@ def get_manifest_schemas_name_dict(template_config_path: Optional[str] = "dca-te
 def get_template_download_link(term: str, schema_names_dict: dict[str, list[str]]) -> str:
     """
     Constructs the download URL for a specific template based on its schema name.
+
     Args:
         term: The name of the template (str).
         schema_names_dict: A dictionary containing the schema names and display names {display_name: [schema_name]}.
+    
     Returns:
         The download URL for the template (str).
     """

--- a/processes/page_manager.py
+++ b/processes/page_manager.py
@@ -141,14 +141,18 @@ def get_manifest_schemas_name_dict(template_config_path: str = "dca-template-con
     Returns:
         A dictionary containing the schema names and display names {display_name: [schema_name]}.
     """
-
+    # The config contains a dictionary of the displaynames and schema names of the components that are in production use, 
+    # some from the schema are excluded
     with open(template_config_path, "r") as f:
         json_template_configdata = json.load(f)
     
+    # Process the dataframe to remove unneeded information and to be stored as a dictionary 
+    # to remove need for more complex df indexing when used later
     schema_names_frame = pd.DataFrame.from_dict(json_template_configdata["manifest_schemas"])
     schema_names_frame.drop('type',axis=1,inplace=True)
     schema_names_frame = schema_names_frame.set_index('display_name').T
 
+    
     return schema_names_frame.to_dict(orient='list')
 
 def get_template_download_link(term: str, schema_names_dict: dict[str, list[str]]) -> str:

--- a/processes/page_manager.py
+++ b/processes/page_manager.py
@@ -28,6 +28,7 @@ import pandas as pd
 from mdutils import fileutils
 from dotenv import dotenv_values
 from glob import glob
+import json
 
 from toolbox import utils
 
@@ -108,6 +109,8 @@ def create_template_page(term: str, term_dict: dict) -> frontmatter.Post:
     post.metadata["title"] = re.sub("_", r" ", term).strip()
     post.metadata["parent"] = term_dict["module"]
 
+    template_url = get_template_download_link(term)
+
     # Inject term information into template content
     content_prefix = (
         "{% assign mydata=site.data."
@@ -115,7 +118,7 @@ def create_template_page(term: str, term_dict: dict) -> frontmatter.Post:
         + " %} \n{: .note-title } \n"
         + f">{post.metadata['title']}\n"
         + ">\n"
-        + f">{term_dict['Description']} [[Source]]({term_dict['Source']})\n"
+        + f">{term_dict['Description']} [[Download]]({template_url})\n"
     )
     post.content = content_prefix + post.content
 
@@ -127,6 +130,21 @@ def create_template_page(term: str, term_dict: dict) -> frontmatter.Post:
 
     # return post
 
+def get_template_download_link(term: str) -> str:
+    base_url = "https://github.com/eliteportal/data-models/raw/refs/heads/"
+    templates_path = "main/elite-data/manifest-templates/"
+    template_prefix = "EL_template_"
+
+    with open("dca-template-config.json", "r") as f:
+        json_template_configdata = json.load(f)
+
+    manifest_schemas = pd.DataFrame.from_dict(json_template_configdata["manifest_schemas"])
+
+    schema_name = manifest_schemas.loc[manifest_schemas["display_name"]==term, "schema_name"].values[0]
+
+    download_url = base_url + templates_path + template_prefix + schema_name + ".xlsx"
+
+    return download_url
 
 def create_table_page(term: str, term_dict: dict) -> fileutils.MarkDownFile:
     """

--- a/processes/page_manager.py
+++ b/processes/page_manager.py
@@ -22,13 +22,13 @@ This Python script provides functions to generate documentation pages for a data
 import os
 import re
 import sys
+import json
 from pathlib import Path
 import frontmatter
 import pandas as pd
 from mdutils import fileutils
 from dotenv import dotenv_values
 from glob import glob
-import json
 from typing import Optional
 
 from toolbox import utils

--- a/processes/page_manager.py
+++ b/processes/page_manager.py
@@ -365,6 +365,10 @@ if __name__ == "__main__":
     templates = list(
         data_model[data_model["Parent"] == "Component"]["Attribute"].unique()
     )
+
+    # assay_phenotype_human_template is currently unused so remove from list to avoide attempting to generate template for it
+    templates.remove('assay_phenotype_human_template')
+    
     for template in templates:
         # term_attr = re.sub("_", " ", template)
         term_info = get_info(data_model, template, column="Attribute")


### PR DESCRIPTION
Now that `Update Metadata Dictionary` completes successfully and modifies files, the changes made to the template pages that allowed for download of the metadata templates in #74 and #75 are being reverted by the `page_manager.py` script.

## Solution
Modify the script to include the download links in the new desired format instead of the old link that led to a 404 error.

## To Test
1. Run the script locally
2. inspect files in `docs/template/` 
3. navigate to the link generated and stored in the markdown files.

## Notes
I was informed that `assay_phenotype_human_template` is not currently used in production. As such this component is also removed from the list of templates to generate since that is not the desired behavior nor necessary at this point. This resolves an error that occurred because it is not in the config's list of components.

I can include the modifed `.md` files in this PR or they can be generated like normal by the workflow. 