### PR TITLE
Update file annotation template - metadataType

### DIFF
--- a/EL.data.model.csv
+++ b/EL.data.model.csv
@@ -161,7 +161,7 @@ experimentalBatchSize,,,,,False,,,,,Unknown,False,,,,assay_metabolomics_template
 grantNumber,Grant number including activity code institute code and serial number (e.g. U01MH103392),"U19AG063893,U24AG051129,U19AG023122,UH2AG064706,UH3AG064706,UH2AG064704,UH3AG064704,R01AG061844, Not assigned",,,True,ManifestColumn,,ManifestColumn,Sage Bionetworks,Unknown,True,STRING_LIST,Sage Bionetworks,,study_folder_template
 isFeatured,,,,,False,,,,,Unknown,False,,,,study_folder_template
 isReleased,,,,,False,,,,,Unknown,False,,,,study_folder_template
-metadataType,"For files of dataSubtype: metadata, a description of the type of metadata in the file","individual,biospecimen,assay,Not Assigned",,,False,ManifestColumn,,ManifestColumn,Sage Bionetworks,Unknown,True,STRING_LIST,Sage Bionetworks,,"study_folder_template, file_annotation_template"
+metadataType,"For files of dataSubtype: metadata, a description of the type of metadata in the file","individual,biospecimen,assay,supplementary files,Not Assigned",,,False,ManifestColumn,,ManifestColumn,Sage Bionetworks,Unknown,True,STRING_LIST,Sage Bionetworks,,"study_folder_template, file_annotation_template"
 methods,,,,,False,,,,,Unknown,False,,,,study_folder_template
 newsRelease,,,,,False,,,,,Unknown,False,,,,study_folder_template
 processingBatchSize,,,,,False,,,,,Unknown,False,,,,assay_metabolomics_template

--- a/EL.data.model.jsonld
+++ b/EL.data.model.jsonld
@@ -11679,6 +11679,9 @@
                     "@id": "bts:Assay"
                 },
                 {
+                    "@id": "bts:Supplementaryfiles"
+                },
+                {
                     "@id": "bts:NotAssigned"
                 }
             ],
@@ -11717,6 +11720,23 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "biospecimen",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:Supplementaryfiles",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "Supplementaryfiles",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:MetadataType"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "supplementary files",
             "sms:required": "sms:false",
             "sms:validationRules": []
         },

--- a/modules/Unknown/metadataType.csv
+++ b/modules/Unknown/metadataType.csv
@@ -1,2 +1,2 @@
 Attribute,Description,Valid Values,DependsOn,DependsOn Component,Required,Parent,Validation Rules,Properties,Source,module,multivalue,columnType,Ontology,Notes,UsedIn
-metadataType,"For files of dataSubtype: metadata, a description of the type of metadata in the file","individual,biospecimen,assay,Not Assigned",,,False,ManifestColumn,,ManifestColumn,Sage Bionetworks,Unknown,True,STRING_LIST,Sage Bionetworks,,"study_folder_template, file_annotation_template"
+metadataType,"For files of dataSubtype: metadata, a description of the type of metadata in the file","individual,biospecimen,assay,supplementary files,Not Assigned",,,False,ManifestColumn,,ManifestColumn,Sage Bionetworks,Unknown,True,STRING_LIST,Sage Bionetworks,,"study_folder_template, file_annotation_template"


### PR DESCRIPTION
Currently, we only use “individual, biospecimen, assay, Not Assigned” as options for annotating metadataType.

Added a new valid value called “supplementary files” for metadataType files such as readme, data dictionary, etc,. that aren’t the three standard metadata formats collected (individual, biospecimen, assay). 

